### PR TITLE
Setupページ追加とルータ変更

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,70 +1,43 @@
-# Getting Started with Create React App
+# emocha - frontend
 
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+## File Structure Overview
 
-## Available Scripts
-
-In the project directory, you can run:
-
-### `npm start`
-
-Runs the app in the development mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in your browser.
-
-The page will reload when you make changes.\
-You may also see any lint errors in the console.
-
-### `npm test`
-
-Launches the test runner in the interactive watch mode.\
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
-
-### `npm run build`
-
-Builds the app for production to the `build` folder.\
-It correctly bundles React in production mode and optimizes the build for the best performance.
-
-The build is minified and the filenames include the hashes.\
-Your app is ready to be deployed!
-
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
-
-### `npm run eject`
-
-**Note: this is a one-way operation. Once you `eject`, you can't go back!**
-
-If you aren't satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
-
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you're on your own.
-
-You don't have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn't feel obligated to use this feature. However we understand that this tool wouldn't be useful if you couldn't customize it when you are ready for it.
-
-## Learn More
-
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
-
-To learn React, check out the [React documentation](https://reactjs.org/).
-
-### Code Splitting
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/code-splitting](https://facebook.github.io/create-react-app/docs/code-splitting)
-
-### Analyzing the Bundle Size
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size](https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size)
-
-### Making a Progressive Web App
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app](https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app)
-
-### Advanced Configuration
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/advanced-configuration](https://facebook.github.io/create-react-app/docs/advanced-configuration)
-
-### Deployment
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/deployment](https://facebook.github.io/create-react-app/docs/deployment)
-
-### `npm run build` fails to minify
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify](https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify)
+```
+frontend/
+    ├ public/
+    |   ├ navIcon/    # ナビゲーションで使用するアイコン
+    |   ├ favion.ico
+    |   ├ index.html
+    |   ├ manifest.json
+    |   └ robots.txt
+    |
+    ├ src/
+    |   ├ components/
+    |   |   ├ api/    # Python ( FastAPI )との通信
+    |   |   |
+    |   |   ├ main/    # 画面を構成するコンポーネントを格納するフォルダ
+    |   |   |   ├ chat/    # Chatページで使用するコンポーネント
+    |   |   |   |   └ parts/    # Chatページで使用するパーツ
+    |   |   |   |
+    |   |   |   ├ globalParts/    # 複数のページで使用されるコンポーネント
+    |   |   |   |
+    |   |   |   └ nav/    # ナビゲーションを表示するコンポーネント
+    |   |   |
+    |   |   ├ providers/    # プロバイダー（グローバル値）を保存
+    |   |   |
+    |   |   ├ router/    # URLなどのルーター設定
+    |   |   |
+    |   |   └ socketio/    # socket.ioでの通信
+    |   |
+    |   ├ pages/    # 表示するページのレイアウト
+    |   |
+    |   ├ App.css    # Twemojiの大きさを定義
+    |   ├ App.jsx    # Rooterを呼び出してページを表示
+    |   ├ index.css    # Tailwind CSSを反映
+    |   └ index.js    # Providerの呼び出し
+    |   
+    ├ .gitignore
+    ├ package-lock.json
+    ├ package.json
+    └ tailwind.config.js    # Tailwind CSSの設定
+```

--- a/frontend/src/components/main/nav/Navigation.jsx
+++ b/frontend/src/components/main/nav/Navigation.jsx
@@ -30,11 +30,11 @@ const Navigation=(props)=>{
                         <UserIcon image={currentUserIcon} color={currentUserIconColor} size={"32"}/>
                     </div>
                 </div>
-                <div className="text-gray-800 mt-8">
-                    {userSettings.name}
+                <div className="text-gray-800 mt-8 w-4 h-4">
+                    {/* {userSettings.id}
                     <span className="inline-block align-text-bottom">
                         <svg fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" viewBox="0 0 24 24" className="w-4 h-4"><path d="M19 9l-7 7-7-7"></path></svg>
-                    </span>
+                    </span> */}
                 </div>
             </div>
 

--- a/frontend/src/components/providers/UserSettingsProvider.jsx
+++ b/frontend/src/components/providers/UserSettingsProvider.jsx
@@ -16,7 +16,8 @@ export const UserSettingsProvider=props=>{
     const [userSettings,setUserSettings]=useState(
         {
             icon:{image:Object.keys(iconsCatalog.image)[0],color:Object.keys(iconsCatalog.color)[0]},
-            name:"",
+            id:"",
+            snsUrl:"",
             language:languagesCatalog[0]
         });
     

--- a/frontend/src/components/providers/UserSettingsProvider.jsx
+++ b/frontend/src/components/providers/UserSettingsProvider.jsx
@@ -1,16 +1,23 @@
-import { createContext,useState } from "react";
+import { createContext,useState,useContext } from "react";
+import { IconsCatalogContext } from "./IconsCatalogProvider";
+import { LanguagesCatalogContext } from "./LanguagesCatalogProvider";
 
 export const UserSettingsContext=createContext({});
 
 export const UserSettingsProvider=props=>{
     const {children}=props;
 
+    // アイコンのデザインセットと言語設定セットを取得
+    const iconsCatalog=useContext(IconsCatalogContext);
+    const languagesCatalog=useContext(LanguagesCatalogContext);
+
+
     // ユーザ設定の初期値と設定を変更する関数を定義
     const [userSettings,setUserSettings]=useState(
         {
-            icon:{image:"Ghost",color:"Purple"},
-            name:"りんごらてオバケ",
-            language:"English"
+            icon:{image:Object.keys(iconsCatalog.image)[0],color:Object.keys(iconsCatalog.color)[0]},
+            name:"",
+            language:languagesCatalog[0]
         });
     
         return (

--- a/frontend/src/components/router/Router.jsx
+++ b/frontend/src/components/router/Router.jsx
@@ -5,11 +5,13 @@ import Home from '../main/Home';
 import Chat from '../main/Chat';
 import Slangs from "../main/Slangs";
 import Settings from '../main/Settings';
+import Setup from "../../pages/Setup";
 
 const Router=()=>{
     return (
         <Routes>
             <Route  path="/" element={<IndexPage />} />
+            <Route path="/setup" element={<Setup />} />
             <Route  path="/main" element={<MainLayout />}>
                 <Route  path="/main/home" element={<Home />} />
                 <Route  path="/main/chat" element={<Chat />} />

--- a/frontend/src/pages/Index.jsx
+++ b/frontend/src/pages/Index.jsx
@@ -10,7 +10,10 @@ const IndexPage=()=>{
                 ログイン / サインアップページ
             </div>
             <NavLink to={"/main/home"} className="navLink bg-gray-400 cursor-pointer">
-                リンク
+                ログイン時のリンク（ホームページに遷移）
+            </NavLink>
+            <NavLink to={"/setup"} className="navLink bg-gray-400 cursor-pointer">
+                サインアップ時のリンク（Setupページに遷移）
             </NavLink>
         </div>
     );

--- a/frontend/src/pages/Setup.jsx
+++ b/frontend/src/pages/Setup.jsx
@@ -71,15 +71,15 @@ const Setup=()=>{
             const response=true; // 実行結果を格納する変数
             if(response===true){
                 setUserSettings(sendData);
-                alert("設定を更新しました！")
+                alert("設定しました！")
             }else{
-                alert("現在、設定を更新することができません。")
-                console.log("更新できませんでした");
+                alert("現在、設定することができません。")
+                console.log("設定できませんでした");
             };
         }catch(error){
             console.log("Fetch Error:",error);
-            alert("現在、設定を更新することができません。")
-            console.log("更新できませんでした");
+            alert("現在、設定することができません。")
+            console.log("設定できませんでした");
         };
     };
 

--- a/frontend/src/pages/Setup.jsx
+++ b/frontend/src/pages/Setup.jsx
@@ -57,6 +57,15 @@ const Setup=()=>{
             }
         );
     };
+    const handleChangeSnsUrl=(event)=>{
+        const newSnsUrl=event.target.value;
+        setPreviews(
+            {
+                    ...previews,
+                snsUrl:newSnsUrl
+            }
+        )
+    }
     // ---------------------------------------------
 
     // ユーザの設定をフロントエンド全体に反映させる
@@ -134,6 +143,9 @@ const Setup=()=>{
                             )
                         })}
                     </select>
+                </div>
+                <div>
+                    <input value={previews.snsUrl} onChange={handleChangeSnsUrl} type="text" id="first_name" placeholder="snsUrl" />
                 </div>
             </div>
             {/* NavLinkがaタグの役割をしている */}

--- a/frontend/src/pages/Setup.jsx
+++ b/frontend/src/pages/Setup.jsx
@@ -1,0 +1,154 @@
+import { useContext,useState } from "react";
+import { NavLink } from "react-router-dom";
+import { IconsCatalogContext } from "../components/providers/IconsCatalogProvider";
+import { LanguagesCatalogContext } from "../components/providers/LanguagesCatalogProvider";
+import { UserSettingsContext } from "../components/providers/UserSettingsProvider";
+import UserIcon from "../components/main/globalParts/UserIcon";
+
+
+const Setup=()=>{
+    // 参考までに/home/settingsで使ったコードの簡易版を置いときます（/components/main/Settings.jsxのやつ）
+    // Settings.jsxをコンポーネント化したかったけど、データ受け渡しがめんどくさくて、できてないです。。。
+
+    // アイコンのデザインセットと言語設定セットを取得
+    const iconsCatalog=useContext(IconsCatalogContext);
+    const languagesCatalog=useContext(LanguagesCatalogContext);
+
+
+    // ユーザ設定を格納するグローバル変数と設定を変更する関数を取得
+    const {userSettings,setUserSettings}=useContext(UserSettingsContext);
+
+    // --------------------------------------
+    // プレビューのための変数
+    const [previews,setPreviews]=useState(userSettings);
+
+
+    // プレビューを更新するハンドラー
+    const handleChangeIconImage=(event)=>{
+        const newImage=event.target.value;
+        setPreviews(
+            {
+                ...previews,
+                icon:{
+                    ...previews.icon,
+                    image:newImage
+                }
+            }
+        );
+    };
+    const handleChangeIconColor=(event)=>{
+        const newColor=event.target.value;
+        setPreviews(
+            {
+                ...previews,
+                icon:{
+                    ...previews.icon,
+                    color:newColor
+                }
+            }
+        );
+    };
+    const handleChangeLanguage=(event)=>{
+        const newLanguage=event.target.value;
+        setPreviews(
+            {
+                ...previews,
+                language:newLanguage
+            }
+        );
+    };
+    // ---------------------------------------------
+
+    // ユーザの設定をフロントエンド全体に反映させる
+
+    // NavLinkボタンをクリックした時の処理
+    const handleClickSend=()=>{
+        const sendData=previews;
+        console.log(sendData);
+        try{
+            // ここでsendDataをバックエンドにpostする
+            // 実行結果（true / false）をもらう
+            const response=true; // 実行結果を格納する変数
+            if(response===true){
+                setUserSettings(sendData);
+                alert("設定を更新しました！")
+            }else{
+                alert("現在、設定を更新することができません。")
+                console.log("更新できませんでした");
+            };
+        }catch(error){
+            console.log("Fetch Error:",error);
+            alert("現在、設定を更新することができません。")
+            console.log("更新できませんでした");
+        };
+    };
+
+    
+    
+    return (
+        <div>
+            <header>
+            </header>
+            <div>
+                <h1>初期設定画面</h1>
+                <p>パスワード</p>
+                <p>ユーザ設定</p>
+                {/* ユーザアイコンを表示するコンポーネント
+                image={使用するイメージ名（iconCatalog.imageのキー値）}
+                color={使用するカラー（iconCatalog.colorのキー値）} 
+                size={アイコンのサイズ}
+                sizeに渡す値と親タグ（例のdivタグ）のサイズを一緒にしないとバグるときがある（バグらないように実装できなくてごめん）
+                例ならsixe=20,divタグはx-20,h-20みたいな
+                */}
+                <div className="mb-4 w-20 h-20">
+                    <UserIcon image={previews.icon.image} color={previews.icon.color} size={20}/>
+                </div>
+
+
+                {/* アイコンのイメージとカラーをselectタグにする例 */}
+                <div>
+                <select value={previews.icon.image} onChange={handleChangeIconImage} id="iconImages" >
+                    {Object.keys(iconsCatalog.image).map((image,index)=>{
+                        return (
+                            <option key={index} value={image}>{image}</option>
+                        )
+                    })}
+                </select>
+                </div>
+
+                {/* 選べる言語をselectタグにする例 */}
+                <div>
+                <select value={previews.icon.color} onChange={handleChangeIconColor} id="iconColors" >
+                    {Object.keys(iconsCatalog.color).map((color,index)=>{
+                        return(
+                            <option key={index} value={color}>{color}</option>
+                        )
+                    })}
+                </select>
+                </div>
+                <div>
+                    <select value={previews.language} onChange={handleChangeLanguage} id="languages">
+                        {languagesCatalog.map((language,index)=>{
+                            return(
+                                <option key={index} value={language}>{language}</option>
+                            )
+                        })}
+                    </select>
+                </div>
+            </div>
+            {/* NavLinkがaタグの役割をしている */}
+
+            {/* IndexページとSetupページで同じUIのリンクボタンを実装するなら、
+            リンクボタンだけコンポーネント化（一つのコードで繰り返し同じ見た目で遷移先が違うリンクボタンとかを使えるようになる）にしても良き
+
+            リンクのコンポーネント化の例としては、components/main/nav/parts/LinkButton.jsxとか（LinkButton.jsxはNavigation.jsxで呼び出してる）
+
+            もし、コンポーネント化するなら、components/globalPartsに新しくファイルを作ってそこにコンポーネント化したものを書いてくれるとありがたいです！ */}
+            <NavLink to={"/main/home"} onClick={handleClickSend} className="navLink bg-gray-400 cursor-pointer">
+                ホームページに遷移
+            </NavLink>
+        </div>
+    );
+};
+
+export default Setup;


### PR DESCRIPTION
## 概要
Setupページの追加とサインアップ / ログインページからホームページまでの遷移を実装 #7 #13 

## なぜこの変更をするのか
チャット開始前にユーザが情報を設定するページが必要だったから

## やったこと

* [x] Setupページを追加（ `/page/Setup.jsx` ）
* [x] Setupページの簡易的なコードを追加
* [x] ユーザがSNSのURLを設定できるようにユーザ設定のグローバル値にSNS URLを格納する場所を追加
* [x] Setupページのパスを追加（ `/setup` ）
* [x] ログイン -> ホームページの遷移を追加
* [x] サインアップ -> Setupページ -> ホームページの遷移を追加
* [x] `/forntend/README.md` に File Structure Overview を追加

## 変更内容

* パス（ `/components/router/Router.jsx` 参照）
* サインアップ後の遷移先を `/setup` に変更
* ユーザ設定にSNS URLを追加（ `/components/providers/UserSettings.jsx` 参照）

## 影響範囲

### ユーザーに影響すること
* 設定できるユーザ情報にSNSのURLが増えた

### メンバーに影響すること
* ログイン / サインアップ / ユーザ情報の設定をするためのページが未完成なので、お願いします！
* レスポンシブ対応だと嬉しい ☺️

### システムに影響すること
* パスが追加された
* ユーザ情報に id（これはバックエンドかフロントエンドでユーザ識別のために自動設定する予定）と susUrl が追加された

## どうやるのか
1. frontend コンテナに入る
2. `npm ci`（feature-frontendブランチで`npm ci`してたら必要ないです！）
3. `npm start`
4. http://localhost:3000/ にアクセス

## 課題
* データ連携の実装全般が未知
* firebaseの認証があんまりわからない

## 備考
データ関係のコードは `/pages/Setup.jsx` に書いてます！
ファイルを分けて管理してるから、わかりにくかったら聞いてください！
というか、絶対分かりにくい。。。書いてる私もときどきわからなくなるから。。。