### PR TITLE
アカウント削除のポップを追加

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.22.3",
+        "react-router-hash-link": "^2.4.3",
         "react-scripts": "5.0.1",
         "react-toggle-dark-mode": "^1.1.1",
         "socket.io-client": "^4.7.4",
@@ -20037,6 +20038,18 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/react-router-hash-link": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/react-router-hash-link/-/react-router-hash-link-2.4.3.tgz",
+      "integrity": "sha512-NU7GWc265m92xh/aYD79Vr1W+zAIXDWp3L2YZOYP4rCqPnJ6LI6vh3+rKgkidtYijozHclaEQTAHaAaMWPVI4A==",
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": ">=15",
+        "react-router-dom": ">=4"
       }
     },
     "node_modules/react-scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.22.3",
+    "react-router-hash-link": "^2.4.3",
     "react-scripts": "5.0.1",
     "react-toggle-dark-mode": "^1.1.1",
     "socket.io-client": "^4.7.4",

--- a/frontend/src/components/main/Settings.jsx
+++ b/frontend/src/components/main/Settings.jsx
@@ -106,10 +106,21 @@ const Settings=()=>{
         alert("アカウントを削除しました！");
         navigate("/");
     };
+    const tailwindNotShowDeleteAccount="hidden"
+    const tailwindShowDeleteAccount="absolute z-20 top-0 p-1 bottom-0 left-0 right-0 m-auto w-80 md:w-96 h-40 min-h-[240px] bg-white border border-gray-200 dark:border-gray-700 dark:shadow-gray-800 rounded-lg shadow flex flex-col dark:bg-gray-800"
+    const [showDeleteAccount,setShowDeleteAccount]=useState(tailwindNotShowDeleteAccount);
+    const handleClickOpenDeleteAccount=()=>{
+        setShowDeleteAccount(tailwindShowDeleteAccount)
+    }
+    const handleClickCloseDeleteAccount=()=>{
+        setShowDeleteAccount(tailwindNotShowDeleteAccount);
+    };
+
+    // ------------------------------------------------
 
     return (
         <div className="h-full overflow-auto">
-        <div className="main flex-1 flex flex-col h-full w-11/12 m-auto">
+        <div className="main flex-1 flex flex-col w-11/12 m-auto">
             <div className="lg:block heading flex-2">
                 <h1 className="text-xl py-3 xl:text-3xl xl:text-gray-700 xl:mb-4  dark:text-white">{userSettings.language==="English"?"Settings":"設定"}</h1>
             </div>
@@ -190,10 +201,10 @@ const Settings=()=>{
                         <div className="md:pl-12">
                             <h2 id="deleteAccount" className="text-xl py-1 mb-8 border-gray-200 dark:text-white">{userSettings.language==="English"?"Delete Account":"アカウント削除"}</h2>
                             <ul>
-                                <li className="my-6 text-lg">{userSettings.language==="English"?"Deleting your account is permanent and cannot be undone.":"一度アカウントを削除すると、二度と元に戻せません。十分ご注意ください。"}</li>
+                                <li className="my-6 text-lg dark:text-white">{userSettings.language==="English"?"Deleting your account is permanent and cannot be undone.":"一度アカウントを削除すると、二度と元に戻せません。十分ご注意ください。"}</li>
                             </ul>
                             <div className="flex justify-center md:justify-start items-center mx-auto">
-                            <button onClick={handleClickDeleteAccount} type="button" className="inline-flex items-center justify-center px-4 py-2.5 text-md font-medium tracking-wide text-white transition-colors duration-200 bg-red-500 rounded-md hover:bg-red-700 focus:ring-2 focus:ring-offset-2 focus:ring-red-700 focus:shadow-outline focus:outline-none">
+                            <button onClick={handleClickOpenDeleteAccount} type="button" className="inline-flex items-center justify-center px-4 py-2.5 text-md font-medium tracking-wide text-white transition-colors duration-200 bg-red-500 rounded-md hover:bg-red-700 focus:ring-2 focus:ring-offset-2 focus:ring-red-700 focus:shadow-outline focus:outline-none">
                                 {userSettings.language==="English"?"Delete account":"アカウント削除"}
                             </button>
                     </div>
@@ -201,6 +212,33 @@ const Settings=()=>{
                     </div>
                 </div>
             </div>
+        </div>
+        <div className={showDeleteAccount}>
+            <div className="flex justify-end items-center">
+                <span onClick={handleClickCloseDeleteAccount} className="inline-block text-gray-700 hover:text-gray-900 align-bottom">
+                    <span className="h-6 w-6 p-1 rounded-md hover:bg-gray-400 dark:hover:bg-gray-700 flex justify-center items-center">
+                        {/* <img src="/navIcon/close.svg" className="dark:text-white" /> */}
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512" className="h-5 w-5 dark:text-white">
+                            {/* <!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--> */}
+                            <path fill="currentColor" d="M342.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192 210.7 86.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L146.7 256 41.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192 301.3 297.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.3 256 342.6 150.6z"/>
+                            </svg>
+                    </span>
+                </span>
+            </div>
+            <div className="px-2">
+                <h3 className="text-xl dark:text-white text-center py-2">{userSettings.language==="English"?"Delete account - Are you sure?":"本当にアカウント削除をしますか？"}</h3>
+                <ul className="px-2">
+                    <li className="my-6 text-lg dark:text-white">{userSettings.language==="English"?"Deleting your account is permanent and cannot be undone.":"一度アカウントを削除すると、二度と元に戻せません。十分ご注意ください。"}</li>
+                </ul>
+            </div>
+            <div className="w-full flex justify-center p-4 pt-0">
+                    <button onClick={handleClickDeleteAccount} type="button" className="mx-5 inline-flex items-center justify-center px-4 py-2 text-sm font-medium tracking-wide text-white transition-colors duration-200 bg-red-600 rounded-md hover:bg-red-700 focus:ring-2 focus:ring-offset-2 focus:ring-red-700 focus:shadow-outline focus:outline-none">
+                    {userSettings.language==="English"?"Delete account":"アカウント削除"}
+                    </button>
+                    <button onClick={handleClickCloseDeleteAccount} type="button" className="mx-5 w-20 inline-flex items-center justify-center px-4 py-2 text-sm font-medium tracking-wide transition-colors duration-200 bg-white border rounded-md text-gray-700 hover:text-gray-900 border-gray-300 hover:bg-gray-100 active:bg-white focus:bg-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-neutral-200/60 focus:shadow-outline">
+                    {userSettings.language==="English"?"Cancel":"キャンセル"}
+                    </button>
+                </div>
         </div>
         </div>
     )

--- a/frontend/src/components/main/Settings.jsx
+++ b/frontend/src/components/main/Settings.jsx
@@ -188,7 +188,7 @@ const Settings=()=>{
                     </div>
                     <div className="border-t border-gray-300 mt-10 py-6">
                         <div className="md:pl-12">
-                            <h2 className="text-xl py-1 mb-8 border-gray-200 dark:text-white">{userSettings.language==="English"?"Delete Account":"アカウント削除"}</h2>
+                            <h2 id="deleteAccount" className="text-xl py-1 mb-8 border-gray-200 dark:text-white">{userSettings.language==="English"?"Delete Account":"アカウント削除"}</h2>
                             <ul>
                                 <li className="my-6 text-lg">{userSettings.language==="English"?"Deleting your account is permanent and cannot be undone.":"一度アカウントを削除すると、二度と元に戻せません。十分ご注意ください。"}</li>
                             </ul>

--- a/frontend/src/components/main/Settings.jsx
+++ b/frontend/src/components/main/Settings.jsx
@@ -189,7 +189,9 @@ const Settings=()=>{
                     <div className="border-t border-gray-300 mt-10 py-6">
                         <div className="md:pl-12">
                             <h2 className="text-xl py-1 mb-8 border-gray-200 dark:text-white">{userSettings.language==="English"?"Delete Account":"アカウント削除"}</h2>
-                            <p className="my-6 text-lg">{userSettings.language==="English"?"Deleting your account is permanent and cannot be undone.":"一度アカウントを削除すると、二度と元に戻せません。十分ご注意ください。"}</p>
+                            <ul>
+                                <li className="my-6 text-lg">{userSettings.language==="English"?"Deleting your account is permanent and cannot be undone.":"一度アカウントを削除すると、二度と元に戻せません。十分ご注意ください。"}</li>
+                            </ul>
                             <div className="flex justify-center md:justify-start items-center mx-auto">
                             <button onClick={handleClickDeleteAccount} type="button" className="inline-flex items-center justify-center px-4 py-2.5 text-md font-medium tracking-wide text-white transition-colors duration-200 bg-red-500 rounded-md hover:bg-red-700 focus:ring-2 focus:ring-offset-2 focus:ring-red-700 focus:shadow-outline focus:outline-none">
                                 {userSettings.language==="English"?"Delete account":"アカウント削除"}

--- a/frontend/src/components/main/Settings.jsx
+++ b/frontend/src/components/main/Settings.jsx
@@ -107,7 +107,7 @@ const Settings=()=>{
         navigate("/");
     };
     const tailwindNotShowDeleteAccount="hidden"
-    const tailwindShowDeleteAccount="absolute z-20 top-0 p-1 bottom-0 left-0 right-0 m-auto w-80 md:w-96 h-40 min-h-[240px] bg-white border border-gray-200 dark:border-gray-700 dark:shadow-gray-800 rounded-lg shadow flex flex-col dark:bg-gray-800"
+    const tailwindShowDeleteAccount="absolute z-20 top-0 p-1 bottom-0 left-0 right-0 m-auto w-80 md:w-96 h-fit bg-white border border-gray-200 dark:border-gray-700 dark:shadow-gray-800 rounded-lg shadow flex flex-col dark:bg-gray-800"
     const [showDeleteAccount,setShowDeleteAccount]=useState(tailwindNotShowDeleteAccount);
     const handleClickOpenDeleteAccount=()=>{
         setShowDeleteAccount(tailwindShowDeleteAccount)
@@ -231,11 +231,11 @@ const Settings=()=>{
                     <li className="my-6 text-lg dark:text-white">{userSettings.language==="English"?"Deleting your account is permanent and cannot be undone.":"一度アカウントを削除すると、二度と元に戻せません。十分ご注意ください。"}</li>
                 </ul>
             </div>
-            <div className="w-full flex justify-center p-4 pt-0">
-                    <button onClick={handleClickDeleteAccount} type="button" className="mx-5 inline-flex items-center justify-center px-4 py-2 text-sm font-medium tracking-wide text-white transition-colors duration-200 bg-red-600 rounded-md hover:bg-red-700 focus:ring-2 focus:ring-offset-2 focus:ring-red-700 focus:shadow-outline focus:outline-none">
+            <div className="w-full flex justify-evenly p-4 pt-0">
+                    <button onClick={handleClickDeleteAccount} type="button" className=" inline-flex items-center justify-center px-4 py-2 text-sm font-medium tracking-wide text-white transition-colors duration-200 bg-red-600 rounded-md hover:bg-red-700 focus:ring-2 focus:ring-offset-2 focus:ring-red-700 focus:shadow-outline focus:outline-none">
                     {userSettings.language==="English"?"Delete account":"アカウント削除"}
                     </button>
-                    <button onClick={handleClickCloseDeleteAccount} type="button" className="mx-5 w-20 inline-flex items-center justify-center px-4 py-2 text-sm font-medium tracking-wide transition-colors duration-200 bg-white border rounded-md text-gray-700 hover:text-gray-900 border-gray-300 hover:bg-gray-100 active:bg-white focus:bg-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-neutral-200/60 focus:shadow-outline">
+                    <button onClick={handleClickCloseDeleteAccount} type="button" className=" inline-flex items-center justify-center px-4 py-2 text-sm font-medium tracking-wide transition-colors duration-200 bg-white border rounded-md text-gray-700 hover:text-gray-900 border-gray-300 hover:bg-gray-100 active:bg-white focus:bg-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-neutral-200/60 focus:shadow-outline">
                     {userSettings.language==="English"?"Cancel":"キャンセル"}
                     </button>
                 </div>

--- a/frontend/src/components/main/Settings.jsx
+++ b/frontend/src/components/main/Settings.jsx
@@ -4,6 +4,7 @@ import { LanguagesCatalogContext } from "../providers/LanguagesCatalogProvider";
 import { UserSettingsContext } from "../providers/UserSettingsProvider";
 import UserIcon from "./globalParts/UserIcon";
 import TranslateIconCatalog from "./globalParts/TranslateIconCatalog";
+import { useNavigate } from "react-router-dom";
 
 const Settings=()=>{
     // アイコンのデザインセットと言語設定セットを取得
@@ -95,6 +96,17 @@ const Settings=()=>{
             console.log("更新できませんでした");
         };
     };
+
+// ----------------------------------------------------
+    // アカウント削除の処理
+    const navigate=useNavigate();
+
+    const handleClickDeleteAccount=()=>{
+        // ここでアカウント削除の処理をする
+        alert("アカウントを削除しました！");
+        navigate("/");
+    };
+
     return (
         <div className="h-full overflow-auto">
         <div className="main flex-1 flex flex-col h-full w-11/12 m-auto">
@@ -173,6 +185,17 @@ const Settings=()=>{
                         <button onClick={handleClickSend} type="button" className="inline-flex items-center justify-center w-36 px-4 py-2.5 text-md font-medium tracking-wide text-white transition-colors duration-200 bg-blue-500 rounded-md hover:bg-blue-700 focus:ring-2 focus:ring-offset-2 focus:ring-blue-700 focus:shadow-outline focus:outline-none">
                             {userSettings.language==="English"?"Save":"保存"}
                         </button>
+                    </div>
+                    <div className="border-t border-gray-300 mt-10 py-6">
+                        <div className="md:pl-12">
+                            <h2 className="text-xl py-1 mb-8 border-gray-200 dark:text-white">{userSettings.language==="English"?"Delete Account":"アカウント削除"}</h2>
+                            <p className="my-6 text-lg">{userSettings.language==="English"?"Deleting your account is permanent and cannot be undone.":"一度アカウントを削除すると、二度と元に戻せません。十分ご注意ください。"}</p>
+                            <div className="flex justify-center md:justify-start items-center mx-auto">
+                            <button onClick={handleClickDeleteAccount} type="button" className="inline-flex items-center justify-center px-4 py-2.5 text-md font-medium tracking-wide text-white transition-colors duration-200 bg-red-500 rounded-md hover:bg-red-700 focus:ring-2 focus:ring-offset-2 focus:ring-red-700 focus:shadow-outline focus:outline-none">
+                                {userSettings.language==="English"?"Delete account":"アカウント削除"}
+                            </button>
+                    </div>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/frontend/src/components/main/Settings.jsx
+++ b/frontend/src/components/main/Settings.jsx
@@ -96,7 +96,8 @@ const Settings=()=>{
         };
     };
     return (
-        <div className="main flex-1 flex flex-col h-full overflow-auto w-11/12 m-auto">
+        <div className="h-full overflow-auto">
+        <div className="main flex-1 flex flex-col h-full w-11/12 m-auto">
             <div className="lg:block heading flex-2">
                 <h1 className="text-xl py-3 xl:text-3xl xl:text-gray-700 xl:mb-4  dark:text-white">{userSettings.language==="English"?"Settings":"設定"}</h1>
             </div>
@@ -175,6 +176,7 @@ const Settings=()=>{
                     </div>
                 </div>
             </div>
+        </div>
         </div>
     )
 };

--- a/frontend/src/components/main/chat/parts/InputEmojis.jsx
+++ b/frontend/src/components/main/chat/parts/InputEmojis.jsx
@@ -6,6 +6,7 @@ import i18n_ja from '@emoji-mart/data/i18n/ja.json';
 import { init } from "emoji-mart";
 import DisplayEmojis from "./DisplayEmojis";
 import { UserSettingsContext } from "../../../providers/UserSettingsProvider";
+import { DarkModeContext } from "../../../providers/DarkModeProviders";
 
 const InputEmojis=()=>{
     useEffect(()=>{
@@ -119,10 +120,14 @@ const InputEmojis=()=>{
         setSlangsList([]);
     }
 
+    // ----------------------------------------------
+    // Pickerのダークモード対応
+    const {isDarkMode}=useContext(DarkModeContext);
+
     return(
         <div className="flex-2 pt-4 pb-6 relative">
             <div id="picker" className={showEmojiPicker}>
-                <Picker data={data} locale={userSettings.language==="English"?"en":"ja"}  noCountryFlags={true} set="twitter" onClickOutside={handleShowEmojiPicker} onEmojiSelect={handleAddEmoji} emojiButtonRadius='6px' previewPosition={"none"}
+                <Picker data={data} theme={isDarkMode?"dark":"light"} locale={userSettings.language==="English"?"en":"ja"}  noCountryFlags={true} set="twitter" onClickOutside={handleShowEmojiPicker} onEmojiSelect={handleAddEmoji} emojiButtonRadius='6px' previewPosition={"none"}
                     emojiButtonColors={[
                     'rgba(155,223,88,.7)',
                     'rgba(149,211,254,.7)',

--- a/frontend/src/components/main/nav/Navigation.jsx
+++ b/frontend/src/components/main/nav/Navigation.jsx
@@ -16,7 +16,7 @@ const Navigation=(props)=>{
     const navTailwind=props.navTailwind;
 
     return (
-        <div className={"xl:block sm:flex-2 w-64 bg-gray-100 shadow dark:bg-gray-800 "+navTailwind}>
+        <div className={"xl:block sm:flex-2 w-64 h-full bg-gray-100 shadow dark:bg-gray-800 "+navTailwind}>
             <div className="p-4 flex justify-end">
                 <span onClick={()=>{handleOpenCloseNav()}} className="xl:hidden inline-block text-gray-700 hover:text-gray-900 align-bottom">
                     <span className="h-6 w-6 p-1 rounded-md hover:bg-gray-400 dark:hover:bg-gray-700 flex justify-center items-center">
@@ -42,7 +42,7 @@ const Navigation=(props)=>{
                 </div>
             </div>
 
-            <div className="menu mt-16 lg:mt-8 ">
+            <div className="menu">
                 <LinkButton svgIcon={"/navIcon/home.svg"} pageName={userSettings.language==="English"?"Home":"ホーム"} to={"/main/home"} />
                 <LinkButton svgIcon={"/navIcon/chat.svg"} pageName={userSettings.language==="English"?"Chat":"チャット"} to={"/main/chat"} />
                 <LinkButton svgIcon={"/navIcon/slangs.svg"} pageName={userSettings.language==="English"?"My slangs":"スラング一覧"} to={"/main/slangs"} />

--- a/frontend/src/pages/Main.jsx
+++ b/frontend/src/pages/Main.jsx
@@ -12,7 +12,7 @@ const MainLayout=()=>{
 
     // ナビゲーションの開閉
     const closeNavTailwind="hidden";
-    const openNavTailwind="absolute z-30 w-full h-full lg:left-0 lg:w-64 z-20";
+    const openNavTailwind="absolute top-0 z-30 w-full h-full lg:left-0 lg:w-64 z-20";
 
     const [navTailwind,setNavTailwind]=useState(closeNavTailwind);
     
@@ -86,11 +86,8 @@ const MainLayout=()=>{
       
 
     return (
-        <div className='flex h-full dark:bg-gray-900' onClick={handleClickOutsideLeaveButton} >
-            <Navigation handleOpenCloseNav={handleOpenCloseNav} navTailwind={navTailwind} />
-            <div className="flex-1 bg-white w-full h-full dark:bg-gray-900">
-            <div className="main-body w-full h-full flex flex-col">
-            <header className="py-2 md:py-4 flex-2 flex flex-row border-b shadow-sm px-4 dark:border-gray-200">
+        <div className='h-full flex flex-col dark:bg-gray-900' onClick={handleClickOutsideLeaveButton} >
+            <header className="py-2 z-20 md:py-4 flex-2 flex flex-row border-b shadow-sm px-4 bg-white dark:bg-gray-900 dark:border-gray-200 sticky top-0">
                 <div className="flex-1 flex">
                     <span onClick={handleOpenCloseNav} className="xl:hidden inline-block text-gray-700 hover:text-gray-900 align-bottom ">
                         <span className="block h-6 w-6 p-1 rounded-md hover:bg-gray-400 dark:hover:bg-gray-700">
@@ -139,7 +136,12 @@ const MainLayout=()=>{
                     </span>
                 </div>
             </header>
+            <div className="flex flex-1 min-h-0 relative">
+            <Navigation handleOpenCloseNav={handleOpenCloseNav} navTailwind={navTailwind} />
+            <div className="flex-1 bg-white w-full h-full dark:bg-gray-900">
+            <div className="main-body w-full h-full flex flex-col">
             <Outlet />
+            </div>
             </div>
             </div>
         </div>

--- a/frontend/src/pages/Main.jsx
+++ b/frontend/src/pages/Main.jsx
@@ -6,6 +6,7 @@ import { UserSettingsContext } from "../components/providers/UserSettingsProvide
 import { DarkModeSwitch } from 'react-toggle-dark-mode';
 import { DarkModeContext } from "../components/providers/DarkModeProviders";
 import LogoSet from "../components/main/globalParts/LogoSet";
+import { HashLink } from 'react-router-hash-link';
 
 const MainLayout=()=>{
     const{userSettings}=useContext(UserSettingsContext);
@@ -57,13 +58,6 @@ const MainLayout=()=>{
     const handleClickLogOut=()=>{
         // ここでログアウト処理をする
         alert("ログアウトしました！");
-        navigate("/");
-    };
-
-    // アカウント削除ボタンの処理
-    const handleClickDeleteAccount=()=>{
-        // ここでアカウント削除の処理をする
-        alert("アカウントを削除しました！");
         navigate("/");
     };
 
@@ -129,9 +123,9 @@ const MainLayout=()=>{
                             <div onClick={handleClickLogOut} className="px-2 rounded-md hover:bg-gray-200 w-full flex cursor-pointer dark:hover:bg-gray-800 dark:hover:text-white">
                                 <p>{userSettings.language==="English"?"Log out":"ログアウト"}</p>
                             </div>
-                            <div onClick={handleClickDeleteAccount} className="px-2 mt-1 rounded-md hover:bg-red-600 hover:text-white w-full flex cursor-pointer">
+                            <HashLink to="/main/settings/#deleteAccount" className="px-2 mt-1 rounded-md hover:bg-red-600 hover:text-white w-full flex cursor-pointer">
                                 <p>{userSettings.language==="English"?"Delete account":"アカウント削除"}</p>
-                            </div>
+                            </HashLink>
                         </div>
                     </span>
                 </div>


### PR DESCRIPTION
## 変更の概要
アカウント削除を設定ページに追加し、アカウント削除時は設定ページのアカウント削除ボタンを押した後に警告ポップを表示してから、アカウント削除を選択してもらうように変更した。 #7 

## なぜこの変更をするのか
一回のクリックでアカウント削除させるのは危険だから

## やったこと

* [x] 設定ページにアカウント削除エリアを追加
* [x] アカウント削除のポップを追加
* [x] ログアウトの下のアカウント削除ボタンを押したときは、設定ページのアカウント削除エリアに遷移するように変更
* [x] Pickerのダークモード対応をプッシュし忘れてたから、このプルリクに追加

## 変更内容
<img width="489" alt="スクリーンショット 2024-03-20 18 57 38" src="https://github.com/hirafish/emocha/assets/103473179/17785ec9-2017-4648-bb38-adb5a88a140c">
