### PR TITLE
アカウント削除機能の実装

### DIFF
--- a/frontend/src/components/main/Settings.jsx
+++ b/frontend/src/components/main/Settings.jsx
@@ -7,6 +7,9 @@ import TranslateIconCatalog from "./globalParts/TranslateIconCatalog";
 import { useNavigate } from "react-router-dom";
 import { db } from "../../firebase/config";
 import { ref, set, get } from "firebase/database";
+import { getAuth, deleteUser } from "firebase/auth";
+
+
 
 const Settings = () => {
   // アイコンのデザインセットと言語設定セットを取得
@@ -111,11 +114,19 @@ const Settings = () => {
   // ----------------------------------------------------
   // アカウント削除の処理
   const navigate = useNavigate();
+  const auth = getAuth();
+  const user = auth.currentUser;
 
   const handleClickDeleteAccount = () => {
-    // ここでアカウント削除の処理をする
-    alert("アカウントを削除しました！");
-    navigate("/");
+    deleteUser(user).then(() => {
+        console.log(user);
+        alert("アカウントを削除しました！");
+        navigate("/");
+      }).catch((error) => {
+        alert("アカウントを削除できませんでした。");
+        
+      });
+    
   };
   const tailwindNotShowDeleteAccount = "hidden";
   const tailwindShowDeleteAccount =

--- a/frontend/src/components/providers/UserSettingsProvider.jsx
+++ b/frontend/src/components/providers/UserSettingsProvider.jsx
@@ -40,6 +40,7 @@ export const UserSettingsProvider = (props) => {
         setUserSettings({
           ...userSettings,
           id: user.uid,
+          
         });
       } else {
         setUserSettings({

--- a/frontend/src/pages/Main.jsx
+++ b/frontend/src/pages/Main.jsx
@@ -90,8 +90,8 @@ const MainLayout = () => {
   }, [isDarkMode]);
 
   if (userSettings.id === null) {
-    return <Navigate replace to="/" />;
     console.log("ログインしていません");
+    return <Navigate replace to="/" />;
   } else {
     return (
       <div


### PR DESCRIPTION
# やったこと
- アカウント削除機能の実装

# やっていないこと
- userSettingProviderの使用
→console.logでデータの中身を見た時にuserImplって表示されるデータを使って削除がしたかったけど、userSettingProviderの中でexportしてるものにそのデータがなかったから、auth=getAuth()→user = auth.currentuserから取ってきてしまってる。userSettingProviderのuserっていう変数にデータが格納されてるっぽいので、これをexportしてもいいのか、要相談。

# 実装画面
- [x]  削除される用に新しく作ったアカウントで確認（nodeleteとは？）
<img width="554" alt="image" src="https://github.com/hirafish/emocha/assets/85686284/9a5bf789-26fb-4320-9e12-d871490771bb">  <br>


- [x] Realtime DatabaseとAuthenticationのどちらにも登録されていることを確認<br>
![IMG_7233](https://github.com/hirafish/emocha/assets/85686284/6119b0fc-aad1-4256-8ae5-fd1e98d5c682)
<img width="837" alt="image" src="https://github.com/hirafish/emocha/assets/85686284/d713f29a-5a3b-4a51-bf62-6e03f5586f53"> <br>
- [x] 削除に成功するとPOPが出る<br>
<img width="466" alt="image" src="https://github.com/hirafish/emocha/assets/85686284/09b0547b-2bef-42fa-bafd-185d27cc632c"> <br>
- [x] Authenticationからは消えてるけど、Realtime Databaseからは消えていない！
