### PR TITLE
アイコンイメージとカラーを追加

### DIFF
--- a/frontend/src/components/main/globalParts/TranslateIconCatalog.js
+++ b/frontend/src/components/main/globalParts/TranslateIconCatalog.js
@@ -15,19 +15,38 @@ const TranslateIconCatalog=(originIconValue)=>{
         Snowman:{ja:"雪だるま"},
         Football:{ja:"サッカーボール"},
         Baseball:{ja:"野球ボール"},
-        Basketball:{ja:"バスケットボール"}       
+        Basketball:{ja:"バスケットボール"},
+        Astronaut:{ja:"宇宙飛行士"},
+        Meteor:{ja:"メテオ"},
+        IceCream:{ja:"アイス"},
+        ChessKing:{ja:"チェスキング"},
+        ChessKnight:{ja:"チェスナイト"},
+        ChessQueen:{ja:"チェスクイーン"},
+        Star:{ja:"スター"},
+        Heart:{ja:"ハート"},
+        Poo:{ja:"うんち"}
     }
     const iconsColors={
         Black:{ja:"ブラック"},
+        Gray:{ja:"グレー"},
         Red:{ja:"レッド"},
         Yellow:{ja:"イエロー"},
         Orange:{ja:"オレンジ"},
+        Amber:{ja:"こはく"},
         Brown:{ja:"ブラウン"},
+        Lime:{ja:"ライム"},
+        Emerald:{ja:"エメラルド"},
+        Teal:{ja:"ティール"},
         Green:{ja:"グリーン"},
+        Cyan:{ja:"シアン"},
+        Sky:{ja:"スカイ"},
         Blue:{ja:"ブルー"},
-        Indigo:{ja:"インディゴ"},
-        Purple:{ja:"パークル"},
-        Pink:{ja:"ピンク"}
+        Indigo:{ja:"あいいろ"},
+        Purple:{ja:"パープル"},
+        Fuchsia:{ja:"フクシャ"},
+        Pink:{ja:"ピンク"},
+        Rose:{ja:"ローズ"},
+        Violet:{ja:"すみれ"}
     }
     let result=undefined;
     if(Object.keys(iconsColors).includes(originIconValue)){

--- a/frontend/src/components/providers/IconsCatalogProvider.jsx
+++ b/frontend/src/components/providers/IconsCatalogProvider.jsx
@@ -1,11 +1,11 @@
 import { createContext } from "react";
 import { library } from '@fortawesome/fontawesome-svg-core';
-import { faGhost,faOtter,faHippo,faDog,faPaw,faCat,faCow,faFish,faDragon,faKiwiBird,faHorse,faFrog,faRocket,faSnowman,faFootball,faBaseball,faBasketball } from '@fortawesome/free-solid-svg-icons';
+import { faGhost,faOtter,faHippo,faDog,faPaw,faCat,faCow,faFish,faDragon,faKiwiBird,faHorse,faFrog,faRocket,faSnowman,faFootball,faBaseball,faBasketball, faUserAstronaut, faMeteor, faIceCream, faChessKing, faStar, faHeart, faPoo, faChessKnight, faChessQueen } from '@fortawesome/free-solid-svg-icons';
 
 export const IconsCatalogContext=createContext({});
 
 export const IconsCatalogProvider= props =>{
-    library.add(faGhost,faOtter,faHippo,faDog,faPaw,faCat,faCow,faFish,faDragon,faKiwiBird,faHorse,faFrog,faRocket,faSnowman,faFootball,faBaseball,faBasketball);
+    library.add(faGhost,faOtter,faHippo,faDog,faPaw,faCat,faCow,faFish,faDragon,faKiwiBird,faHorse,faFrog,faRocket,faSnowman,faFootball,faBaseball,faBasketball,faUserAstronaut,faMeteor,faIceCream,faChessKing,faChessKnight,faChessQueen,faStar,faHeart,faPoo);
 
     // アイコンのデザインセットを定義
     // 翻訳も定義すること！！（../glabalParts/TranslateIconCatalog.ls）
@@ -25,19 +25,38 @@ export const IconsCatalogProvider= props =>{
         Snowman:{fontAwesomeValue:"fa-snowman"},
         Football:{fontAwesomeValue:"fa-football"},
         Baseball:{fontAwesomeValue:"fa-baseball"},
-        Basketball:{fontAwesomeValue:"fa-basketball"}       
+        Basketball:{fontAwesomeValue:"fa-basketball"},
+        Astronaut:{fontAwesomeValue:"fa-user-astronaut"},
+        Meteor:{fontAwesomeValue:"fa-meteor"},
+        IceCream:{fontAwesomeValue:"fa-ice-cream"},
+        ChessKing:{fontAwesomeValue:"fa-chess-king"},
+        ChessKnight:{fontAwesomeValue:"fa-chess-knight"},
+        ChessQueen:{fontAwesomeValue:"fa-chess-queen"},
+        Star:{fontAwesomeValue:"fa-star"},
+        Heart:{fontAwesomeValue:"fa-heart"},
+        Poo:{fontAwesomeValue:"fa-poo"}
     }
     const iconsColorCatalog={
         Black:{tailwindClass:"text-balack"},
-        Red:{tailwindClass:"text-red-600"},
-        Yellow:{tailwindClass:"text-yellow-300"},
-        Orange:{tailwindClass:"text-yellow-500"},
+        Gray:{tailwindClass:"text-gray-500"},
+        Red:{tailwindClass:"text-red-500"},
         Brown:{tailwindClass:"text-yellow-800"},
-        Green:{tailwindClass:"text-green-600"},
-        Blue:{tailwindClass:"text-blue-600"},
+        Orange:{tailwindClass:"text-yellow-500"},
+        Amber:{tailwindClass:"text-amber-500"},
+        Yellow:{tailwindClass:"text-yellow-500"},
+        Lime:{tailwindClass:"text-lime-500"},
+        Green:{tailwindClass:"text-green-500"},
+        Emerald:{tailwindClass:"text-emerald-500"},
+        Teal:{tailwindClass:"text-teal-500"},
+        Cyan:{tailwindClass:"text-cyan-500"},
+        Sky:{tailwindClass:"text-sky-500"},
+        Blue:{tailwindClass:"text-blue-500"},
         Indigo:{tailwindClass:"text-indigo-500"},
-        Purple:{tailwindClass:"text-purple-400"},
-        Pink:{tailwindClass:"text-pink-400"}
+        Violet:{tailwindClass:"text-violet-500"},
+        Purple:{tailwindClass:"text-purple-500"},
+        Fuchsia:{tailwindClass:"text-fuchsia-500"},
+        Pink:{tailwindClass:"text-pink-500"},
+        Rose:{tailwindClass:"text-rose-500"},
     }
 
     const iconsCatalog={


### PR DESCRIPTION
## 変更の概要
アイコンイメージとカラーを追加した。 #7 

## 変更内容
### image
<img width="389" alt="スクリーンショット 2024-03-22 21 09 42" src="https://github.com/hirafish/emocha/assets/103473179/9796844f-14fc-4e3c-97e9-c7eb7551dc8b">
<img width="382" alt="スクリーンショット 2024-03-22 21 10 58" src="https://github.com/hirafish/emocha/assets/103473179/27ea13ae-fb3d-4a18-9f86-4ae4233bb0a1">

### color
<img width="382" alt="スクリーンショット 2024-03-22 21 10 36" src="https://github.com/hirafish/emocha/assets/103473179/43c9b4dc-529b-4f4d-9e9d-255be5a1b7e1">
<img width="345" alt="スクリーンショット 2024-03-22 21 12 44" src="https://github.com/hirafish/emocha/assets/103473179/3cdcc477-8a06-42d8-b4e5-c56a677ea424">
