### PR TITLE
スキントーン修正、同じ絵文字が2回以上表示されないようにした

### DIFF
--- a/frontend/src/components/main/chat/parts/SlangInfo.jsx
+++ b/frontend/src/components/main/chat/parts/SlangInfo.jsx
@@ -13,7 +13,9 @@ const SlangInfo=({slangsList})=>{
                     <span className="w-full flex flex-col justify-center items-center">
                         {slangsList.map((slangObj,index)=>{
                             return(
-                            <p key={index} className="h-4 flex items-center dark:text-white"><DisplayEmojis emojiShortcodesList={[slangObj.shortcodes]} /> {userSettings.language === "English"?"means":"は、英語で"} " {slangObj.meaning} " {userSettings.language === "English"?"in Japanese.":"という意味です"}</p>
+                                <div className="h-auto items-center  dark:text-white">
+                                    <p key={index} className=" mb-1 flex "><DisplayEmojis emojiShortcodesList={[slangObj.shortcodes]} /> {userSettings.language === "English"?"means":"は、英語で"} " {slangObj.meaning} " {userSettings.language === "English"?"in Japanese.":"という意味です"}</p>
+                                </div>
                             )
                         })}
                     </span>

--- a/frontend/src/components/main/slangs/CheckSlangs.jsx
+++ b/frontend/src/components/main/slangs/CheckSlangs.jsx
@@ -9,6 +9,7 @@ import { EnglishSlangContext } from "../../providers/EnglishSlangProvider"
 const JapaneseCheckSlangs = (postData) => {
     const { japaneseSlang } = useContext( JapaneseSlangContext );
     let slangList = [];
+    let uniqueSlangList = [];
 
     for (let i = 0; i < postData.length; i++) {
         let slangObject = {};
@@ -20,9 +21,22 @@ const JapaneseCheckSlangs = (postData) => {
             slangObject.meaning = japaneseSlang.Japanese[postData[i]].meaning;
             slangObject.isbad = japaneseSlang.Japanese[postData[i]].isbad;
 
+        }else if(postData[i].includes("skin-tone")){
+            let word = postData[i].substring(0, 11);
+            console.log(word);
+            if (Object.keys(japaneseSlang.Japanese).includes(word)) {
+                slangFlag = true;
+                slangObject.shortcodes = word;
+                slangObject.meaning = japaneseSlang.Japanese[word].meaning;
+                slangObject.isbad = japaneseSlang.Japanese[word].isbad;
+            }            
         }
+
         if (slangFlag){
-            slangList.push(slangObject);
+            if (!uniqueSlangList.includes(slangObject.shortcodes)){
+                uniqueSlangList.push(slangObject.shortcodes);
+                slangList.push(slangObject);
+            }
             slangFlag = false;
         }  
         
@@ -37,6 +51,7 @@ const EnglishCheckSlangs = (postData) => {
 
     const { EnglishSlang } = useContext( EnglishSlangContext );
     let slangList = [];
+    let uniqueSlangList = [];
 
     for (let i = 0; i < postData.length; i++) {
         let slangObject = {};
@@ -48,11 +63,25 @@ const EnglishCheckSlangs = (postData) => {
             slangObject.meaning = EnglishSlang.English[postData[i]].meaning;
             slangObject.isbad = EnglishSlang.English[postData[i]].isbad;
 
+        }else if(postData[i].includes("skin-tone")){
+            let word = postData[i].substring(0, 11);
+            console.log(word);
+            if (Object.keys(EnglishSlang.English).includes(word)) {
+                slangFlag = true;
+                slangObject.shortcodes = word;
+                slangObject.meaning = EnglishSlang.English[word].meaning;
+                slangObject.isbad = EnglishSlang.English[word].isbad;
+            }            
         }
+
+
         if (slangFlag){
-            slangList.push(slangObject);
+            if (!uniqueSlangList.includes(slangObject.shortcodes)){
+                uniqueSlangList.push(slangObject.shortcodes);
+                slangList.push(slangObject);
+            }
             slangFlag = false;
-        }        
+        }       
     }
     return slangList;
 


### PR DESCRIPTION
# やったこと
- スキントーンを変えていてもちゃんとスラングが表示されるようにした。
- 同じ絵文字に２回以上説明が表示されないようにした。

# 変更内容
- [x] スキントーンが白い肌でも、きちんと対応できている<br>
<img width="315" alt="image" src="https://github.com/hirafish/emocha/assets/85686284/094490ea-1ba5-4e38-a43f-87799156635f"> <br>

- [x] 同じ絵文字に２回以上説明が表示されていない
<img width="319" alt="image" src="https://github.com/hirafish/emocha/assets/85686284/cf7fdbfd-4516-4653-b370-ff53b160bc7a">

